### PR TITLE
Fix data URLs

### DIFF
--- a/src/nimview.nim
+++ b/src/nimview.nim
@@ -266,9 +266,9 @@ when not defined(just_core):
     if stream.startsWith("data:"):
       return stream
     if (system.hostOS == "windows"): 
-      result = "data:text/html, " & stream.replace("%", uri.encodeUrl("%")) 
+      result = "data:text/html," & stream.replace("%", uri.encodeUrl("%")) 
     else:
-      result = "data:text/html;base64, " & base64.encode(stream)
+      result = "data:text/html;base64," & base64.encode(stream)
 
   proc startDesktop*(indexHtmlFile: string = nimviewSettings.indexHtmlFile, 
         title: string = nimviewSettings.title,


### PR DESCRIPTION
Extra space is [not needed](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs#syntax) ([rfc](https://datatracker.ietf.org/doc/html/rfc2397#section-2)) and leads to blank page to be rendered insead of expected `../dist/inlined.html` on macOS 10.14.6 (not tested with other versions).